### PR TITLE
Add a safeguard against calls without event 

### DIFF
--- a/src/fx/tracking.js
+++ b/src/fx/tracking.js
@@ -24,6 +24,13 @@
 			me: 'Tracking',
 			args: ['%cpush(' + options + ');', 'color:cornflowerblue']
 		});
+		if (!options.event) {
+			App.log({
+				me: 'Tracking',
+				fx: 'error',
+				args: ['Missing event property in push call']
+			});
+		}
 	};
 
 	const push = (options) => {

--- a/src/fx/tracking.js
+++ b/src/fx/tracking.js
@@ -19,18 +19,19 @@
 	};
 
 	const log = (options) => {
-		options = JSON.stringify(options, null, 2);
-		App.log({
-			me: 'Tracking',
-			args: ['%cpush(' + options + ');', 'color:cornflowerblue']
-		});
-		if (!options.event) {
+		if (!options || !options.event) {
 			App.log({
 				me: 'Tracking',
 				fx: 'error',
 				args: ['Missing event property in push call']
 			});
 		}
+
+		options = JSON.stringify(options, null, 2);
+		App.log({
+			me: 'Tracking',
+			args: ['%cpush(' + options + ');', 'color:cornflowerblue']
+		});
 	};
 
 	const push = (options) => {


### PR DESCRIPTION
This makes the calls useless as we need at lest this property to be able
to catch the data in GTM