### PR TITLE
Set advancedSyntax in query params

### DIFF
--- a/src/com/algolia-search.js
+++ b/src/com/algolia-search.js
@@ -208,7 +208,8 @@
 				attributesToHighlight: o.algoliaAttributesToHighlight,
 				restrictSearchableAttributes: o.algoliaSearchableAttributes,
 				highlightPreTag: o.highlightPreTag,
-				highlightPostTag: o.highlightPostTag
+				highlightPostTag: o.highlightPostTag,
+				advancedSyntax: isMultipleWords
 			};
 
 			if (ctn.filter('[data-algolia-filters-mode=filters]').length) {
@@ -222,7 +223,6 @@
 				query: {
 					indexName: o.algolia.index,
 					query: val,
-					advancedSyntax: isMultipleWords,
 					params: queryParams
 				}
 			};


### PR DESCRIPTION
To work, advancedSyntax needs to be set in the params of the query. Wehere it was before will not activate it when having multiple word in the search query.